### PR TITLE
Alt screen view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "anyhow",
  "cgmath",
  "cosmic-text",
+ "derive_more",
  "env_logger",
  "futures",
  "getrandom 0.2.16",

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,11 +173,11 @@ impl MassiveTerminal {
             matrix: view_matrix.clone(),
         });
 
-        let view_gen = move |scene: &Scene| {
+        let view_gen = move |scene: &Scene, scroll_offset| {
             TerminalView::new(
                 font_system.clone(),
                 terminal_font.clone(),
-                scene.timeline(0.0),
+                scroll_offset,
                 view_location.clone(),
                 scene,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,10 @@ use wezterm_term::{KeyCode, KeyModifiers, StableRowIndex, Terminal, TerminalConf
 
 use massive_geometry::{Camera, Color, Identity};
 use massive_input::{EventManager, ExternalEvent, Movement};
-use massive_scene::{Handle, Location, Matrix, Scene};
-use massive_shell::{ApplicationContext, AsyncWindowRenderer, ShellEvent, ShellWindow, shell};
+use massive_scene::{Handle, Location, Matrix};
+use massive_shell::{
+    ApplicationContext, AsyncWindowRenderer, Scene, ShellEvent, ShellWindow, shell,
+};
 
 mod input;
 mod logical_line;
@@ -66,7 +68,6 @@ struct MassiveTerminal {
     terminal: Arc<Mutex<Terminal>>,
 
     scene: Scene,
-    view: TerminalView,
     view_matrix: Handle<Matrix>,
 
     event_manager: EventManager,
@@ -172,16 +173,20 @@ impl MassiveTerminal {
             matrix: view_matrix.clone(),
         });
 
-        let view = TerminalView::new(
-            font_system,
-            terminal_font,
-            context.timeline(0.0),
-            view_location,
-            &scene,
-        );
+        let view_gen = move |scene: &Scene| {
+            TerminalView::new(
+                font_system.clone(),
+                terminal_font.clone(),
+                scene.timeline(0.0),
+                view_location.clone(),
+                scene,
+            )
+        };
 
         let terminal_scroller =
-            TerminalScroller::new(&context, Duration::from_secs(1), Duration::from_secs(1));
+            TerminalScroller::new(&scene, Duration::from_secs(1), Duration::from_secs(1));
+
+        let terminal_state = TerminalState::new(view_gen, last_rendered_seq_no, &scene);
 
         Ok(Self {
             context,
@@ -190,11 +195,10 @@ impl MassiveTerminal {
             pty_pair,
             terminal,
             scene,
-            view,
             view_matrix,
             event_manager: EventManager::default(),
             window_state: WindowState::new(window_geometry),
-            terminal_state: TerminalState::new(last_rendered_seq_no),
+            terminal_state,
             terminal_scroller,
             selecting: None,
             clipboard: Clipboard::new()?,
@@ -238,11 +242,9 @@ impl MassiveTerminal {
             // Performance: We begin an update cycle whenever the terminal advances, too. This
             // should probably be done asynchronously, deferred, etc. But note that the renderer is
             // also running asynchronously at the end of the update cycle.
-            let _cycle = self.context.begin_update_cycle(
-                &self.scene,
-                &mut self.renderer,
-                shell_event_opt.as_ref(),
-            )?;
+            let _cycle = self
+                .scene
+                .begin_update_cycle(&mut self.renderer, shell_event_opt.as_ref())?;
 
             // Architecture: We need to enforce running animations _inside_ the update cycle
             // somehow. Otherwise this can lead to confusing bugs, for example if the following code
@@ -255,23 +257,11 @@ impl MassiveTerminal {
                 self.terminal_scroller.proceed();
             }
 
-            // Currently we need always apply view animations, otherwise the scroll matrix is not
-            // in sync with the updated lines which results in flickering while scrolling (i.e.
-            // lines disappearing too early when scrolling up).
-            //
-            // Architecture: This is a pointer to what's actually wrong with the ApplyAnimations
-            // concept.
-            self.view.apply_animations();
-
             {
                 // Update lines & cursor
 
-                self.terminal_state.update(
-                    &self.terminal,
-                    &self.window_state,
-                    &mut self.view,
-                    &self.scene,
-                )?;
+                self.terminal_state
+                    .update(&self.terminal, &self.window_state, &self.scene)?;
             }
 
             // Center

--- a/src/terminal/scroller.rs
+++ b/src/terminal/scroller.rs
@@ -2,7 +2,7 @@
 use std::time::Duration;
 
 use massive_animation::{Interpolation, Timeline};
-use massive_shell::ApplicationContext;
+use massive_shell::Scene;
 
 #[allow(unused)]
 #[derive(Debug)]
@@ -31,14 +31,9 @@ enum ScrollAnimationState {
 
 #[allow(unused)]
 impl TerminalScroller {
-    // Gorilla: ApplicationContext
-    pub fn new(
-        ctx: &ApplicationContext,
-        phase_in_duration: Duration,
-        phase_out_duration: Duration,
-    ) -> Self {
-        let velocity = ctx.timeline(0.0);
-        let scroll_offset = ctx.timeline(0.0);
+    pub fn new(scene: &Scene, phase_in_duration: Duration, phase_out_duration: Duration) -> Self {
+        let velocity = scene.timeline(0.0);
+        let scroll_offset = scene.timeline(0.0);
 
         Self {
             phase_in_duration,

--- a/src/terminal/state.rs
+++ b/src/terminal/state.rs
@@ -20,30 +20,31 @@ use wezterm_term::{CursorPosition, Line, StableRowIndex, Terminal};
 #[derive(Debug)]
 pub struct TerminalState {
     #[debug(skip)]
-    // view_gen: Box<dyn Fn(&Scene) -> TerminalView + Send>,
+    #[allow(clippy::type_complexity)]
+    view_gen: Box<dyn Fn(&Scene, StableRowIndex) -> TerminalView + Send>,
     pub last_rendered_seq_no: SequenceNo,
-    // For scroll detection. Primary screen only.
-    pub current_stable_top_primary: StableRowIndex,
     temporary_line_buf: Vec<Line>,
     selection: Selection,
     view: TerminalView,
+    alt_screen_active: bool,
 }
 
 impl TerminalState {
     pub fn new(
-        view_gen: impl Fn(&Scene) -> TerminalView + Send + 'static,
+        view_gen: impl Fn(&Scene, StableRowIndex) -> TerminalView + Send + 'static,
         last_rendered_seq_no: SequenceNo,
         scene: &Scene,
     ) -> Self {
-        let view = view_gen(scene);
+        let view = view_gen(scene, 0);
         Self {
+            view_gen: Box::new(view_gen),
             last_rendered_seq_no,
-            current_stable_top_primary: 0,
             temporary_line_buf: Vec::new(),
 
             selection: Default::default(),
             // view_gen: Box::new(view_gen),
             view,
+            alt_screen_active: false,
         }
     }
 
@@ -65,9 +66,26 @@ impl TerminalState {
         view.apply_animations();
 
         let terminal = terminal.lock().unwrap();
-        let alt_screen_active = terminal.is_alt_screen_active();
-
         let screen = terminal.screen();
+
+        // Switch between primary and alt screen.
+        {
+            let alt_screen_active = terminal.is_alt_screen_active();
+            if alt_screen_active != self.alt_screen_active {
+                // Switch
+                let scroll_offset = screen.visible_row_to_stable_row(0);
+                info!(
+                    "Switching to {} view at scroll offset {scroll_offset}",
+                    if alt_screen_active {
+                        "alternate"
+                    } else {
+                        "primary"
+                    }
+                );
+                *view = (self.view_gen)(scene, scroll_offset);
+                self.alt_screen_active = alt_screen_active;
+            }
+        }
 
         // Performance: No need to begin an update cycle if there are no visible changes
         let current_seq_no = terminal.current_seqno();
@@ -86,13 +104,7 @@ impl TerminalState {
         // We need to scroll first, so that the visible range is up to date (even though this
         // should not make a difference when the view is currently animating).
         let stable_top_in_screen_view = screen.visible_row_to_stable_row(0);
-        if !alt_screen_active && stable_top_in_screen_view != self.current_stable_top_primary {
-            let scroll_amount = stable_top_in_screen_view - self.current_stable_top_primary;
-            if scroll_amount != 0 {
-                view.scroll(scroll_amount);
-            }
-            self.current_stable_top_primary = stable_top_in_screen_view;
-        }
+        view.scroll_to(stable_top_in_screen_view);
 
         // Get the stable view range from the view. It can't be computed here, because of the
         // animation range.
@@ -108,9 +120,8 @@ impl TerminalState {
             // correct range of updated lines (which it doesn't if lines are requested outside of
             // its scrollback buffer).
 
-            let current_terminal_stable_phys_range = self
-                .current_stable_top_primary
-                .with_len(screen.physical_rows);
+            let current_terminal_stable_phys_range =
+                stable_top_in_screen_view.with_len(screen.physical_rows);
 
             if !current_terminal_stable_phys_range.intersects(&view_stable_range) {
                 debug!("Resetting scrolling animation (terminal view is far away from ours)");
@@ -120,7 +131,7 @@ impl TerminalState {
 
             info!(
                 "View's stable range: {view_stable_range:?}, current top: {}",
-                self.current_stable_top_primary
+                view.scroll_offset()
             );
         }
 
@@ -227,9 +238,6 @@ impl TerminalState {
 
     pub fn visible_cell_to_selection_pos(&self, vis_cell: (usize, usize)) -> SelectionPos {
         // Bug: What about secondary screen?
-        SelectionPos::new(
-            vis_cell.0,
-            vis_cell.1 as isize + self.current_stable_top_primary,
-        )
+        SelectionPos::new(vis_cell.0, vis_cell.1 as isize + self.view.scroll_offset())
     }
 }


### PR DESCRIPTION
This PR generates a new view when the terminal switches from primary to alt screen or back. This way we can later add some fancy transitions and as a side effect fix the crash that appeared when the primary screen was scrolled and switching to the alternate.