### PR TITLE
Selection scrolling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "arboard",
+        "blendings",
         "cellcluster",
         "openpty",
         "rangeset",

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,7 +430,7 @@ impl MassiveTerminal {
         let mut s = String::new();
         // Feature: Rectangular selection.
         let rectangular = false;
-        let Some(sel) = self.presenter.selection().range() else {
+        let Some(sel) = self.presenter.selection_range() else {
             return s;
         };
         let mut last_was_wrapped = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,14 +246,14 @@ impl MassiveTerminal {
             // Performance: We begin an update cycle whenever the terminal advances, too. This
             // should probably be done asynchronously, deferred, etc. But note that the renderer is
             // also running asynchronously at the end of the update cycle.
+            //
+            // Architecture: We need to enforce running animations _inside_ the update cycle
+            // somehow. Otherwise this can lead to confusing bugs, for example if the following code
+            // does run before begin_update_cycle().
             let _cycle = self
                 .scene
                 .begin_update_cycle(&mut self.renderer, shell_event_opt.as_ref())?;
 
-            // Architecture: We need to enforce running animations _inside_ the update cycle
-            // somehow. Otherwise this can lead to confusing bugs, for example if the following code
-            // does run before begin_update_cycle().
-            //
             // Idea: Make shell_event opaque and allow checking for animations update in UpdateCycle
             // that is returned from begin_update_cycle()?
             if matches!(shell_event_opt, Some(ShellEvent::ApplyAnimations)) {
@@ -262,7 +262,7 @@ impl MassiveTerminal {
             }
 
             {
-                // Update lines & cursor
+                // Update lines & cursor.
 
                 self.presenter.update(&self.window_state, &self.scene)?;
             }
@@ -329,19 +329,8 @@ impl MassiveTerminal {
                 if let Some(progress) = movement.track_to(&ev) {
                     let progress = progress.map_or_cancel(hit_view_matrix);
 
-                    // Scroll?
-                    if let Some(view_hit) = progress.proceeds() {
-                        let pixel_velocity = self.presenter.geometry().scroll_distance(*view_hit);
-                        if let Some(scroll) = pixel_velocity {
-                            self.terminal_scroller.set_velocity(scroll);
-                        }
-                    }
-
-                    // Map to selection.
-                    // Robustness: Should we support negative cell hits, so that the selection can always progress here?
-
                     assert!(self.presenter.selection_can_progress());
-                    self.presenter.selection_progress(progress);
+                    self.presenter.selection_progress(&self.scene, progress);
 
                     if progress.ends() {
                         self.selecting = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,9 @@ impl MassiveTerminal {
                                 self.paste()?
                             }
                             _ => {
+                                // Architecture: Should probably move into the presenter which owns terminal now.
                                 self.terminal().lock().key_down(key, modifiers)?;
+                                self.presenter.enable_autoscroll();
                             }
                         },
                         ElementState::Released => {
@@ -412,6 +414,7 @@ impl MassiveTerminal {
         let text = self.clipboard.get_text()?;
         if !text.is_empty() {
             self.terminal().lock().send_paste(&text)?;
+            self.presenter.enable_autoscroll();
         }
         Ok(())
     }

--- a/src/terminal/geometry.rs
+++ b/src/terminal/geometry.rs
@@ -72,7 +72,7 @@ impl TerminalGeometry {
     /// Decide if scrolling is needed and how many pixels the hit position lies away from.
     ///
     /// Negative values scroll up, positives, scroll down.
-    pub fn scroll_distance(&self, view_hit: PixelPoint) -> Option<f64> {
+    pub fn scroll_distance_px(&self, view_hit: PixelPoint) -> Option<f64> {
         let hit_y = view_hit.y;
 
         if hit_y < 0.0 {

--- a/src/terminal/presenter.rs
+++ b/src/terminal/presenter.rs
@@ -125,6 +125,9 @@ impl TerminalPresenter {
         let columns = screen.physical_cols;
 
         // Switch between primary and alt screen.
+        //
+        // Architecture: If we do switch here, we overwrite all scrolling / apply animations done
+        // above, this seems broken.
         {
             let alt_screen_active = terminal.is_alt_screen_active();
             if alt_screen_active != self.alt_screen_active {

--- a/src/terminal/presenter.rs
+++ b/src/terminal/presenter.rs
@@ -162,17 +162,17 @@ impl TerminalPresenter {
             .visible_row_to_stable_row(0)
             .with_len(screen.physical_rows);
 
-        // The range the terminal has line data for.
-        let terminal_full_stable_range = screen.phys_to_stable_row_index(0).with_len(
-            screen.scrollback_rows(), /* does include the visible part */
-        );
-
         // We need to scroll first, so that the visible range is up to date (even though this should
         // not make a difference when the view is currently animating, because animations are not
         // instantly applied).
         if self.auto_scroll {
             view.scroll_to_stable(terminal_visible_stable_range.start);
         }
+
+        // The range the terminal has line data for.
+        let terminal_full_stable_range = screen.phys_to_stable_row_index(0).with_len(
+            screen.scrollback_rows(), /* does include the visible part */
+        );
 
         // Get the range of lines the view is showing currently.
         let view_stable_range = view.geometry(&self.geometry).stable_range;

--- a/src/terminal/presenter.rs
+++ b/src/terminal/presenter.rs
@@ -73,6 +73,10 @@ impl TerminalPresenter {
         &self.geometry
     }
 
+    pub fn enable_autoscroll(&mut self) {
+        self.auto_scroll = true;
+    }
+
     // Returns `true` if the terminal size in cells changed.
     pub fn resize(&mut self, new_size_px: (u32, u32)) -> Result<bool> {
         let mut new_geometry = self.geometry;
@@ -249,6 +253,7 @@ impl TerminalPresenter {
         }
 
         let cursor_pos = terminal.cursor_pos();
+        let cursor_stable_y = terminal_visible_stable_range.start + cursor_pos.y as StableRowIndex;
 
         // ADR: Need to keep the time we lock the Terminal as short as possible, so that terminal
         // changes can be pushed to it as fast as possible.
@@ -286,7 +291,7 @@ impl TerminalPresenter {
 
         // Update cursor and selection
 
-        view_update.cursor(cursor_pos, window_state.focused);
+        view_update.cursor(cursor_pos, cursor_stable_y, window_state.focused);
 
         {
             // Clear the selection if changes intersect it and the user does not interact with it.

--- a/src/terminal/presenter.rs
+++ b/src/terminal/presenter.rs
@@ -333,16 +333,14 @@ impl TerminalPresenter {
         match progress {
             Progress::Proceed(view_hit) => {
                 // Scroll?
-                if let Some(view_hit) = progress.proceeds() {
-                    let pixel_velocity = self.geometry().scroll_distance_px(*view_hit);
-                    if let Some(velocity) = pixel_velocity {
-                        self.scroll_selection(
-                            scene,
-                            velocity * Self::PIXEL_TO_SCROLL_VELOCITY_PER_SECOND,
-                        )
-                    } else {
-                        self.clear_selection_scroller()
-                    }
+                let pixel_velocity = self.geometry().scroll_distance_px(view_hit);
+                if let Some(velocity) = pixel_velocity {
+                    self.scroll_selection(
+                        scene,
+                        velocity * Self::PIXEL_TO_SCROLL_VELOCITY_PER_SECOND,
+                    )
+                } else {
+                    self.clear_selection_scroller()
                 }
 
                 self.selection.progress(view_hit);

--- a/src/terminal/scroll_locations.rs
+++ b/src/terminal/scroll_locations.rs
@@ -88,7 +88,7 @@ impl ScrollLocations {
         let line_height = self.line_height_px;
         self.locations.iter_mut().for_each(|(index, location)| {
             let base_offset = Self::bucket_base_scroll_offset(*index, line_height);
-            let new_scroll_offset = base_offset as i64 - scroll_offset_px;
+            let new_scroll_offset = base_offset - scroll_offset_px;
             if new_scroll_offset != location.matrix_scroll_offset_px {
                 location.matrix_scroll_offset_px = new_scroll_offset;
                 location

--- a/src/terminal/scroll_locations.rs
+++ b/src/terminal/scroll_locations.rs
@@ -18,7 +18,7 @@ pub struct ScrollLocations {
     parent: Handle<Location>,
     line_height_px: u32,
     /// The current scroll offset in pixels.
-    scroll_offset_px: u64,
+    scroll_offset_px: i64,
     // Performance: Use a simple vec here.
     locations: HashMap<BucketKey, ScrollLocation>,
 }
@@ -37,7 +37,7 @@ struct ScrollLocation {
 }
 
 impl ScrollLocations {
-    pub fn new(parent: Handle<Location>, line_height_px: u32, scroll_offset_px: u64) -> Self {
+    pub fn new(parent: Handle<Location>, line_height_px: u32, scroll_offset_px: i64) -> Self {
         Self {
             parent,
             line_height_px,
@@ -84,7 +84,7 @@ impl ScrollLocations {
     }
 
     /// Scroll the _current_ scroll offset of all matrices to the pixel location.
-    pub fn set_scroll_offset_px(&mut self, scroll_offset_px: u64) {
+    pub fn set_scroll_offset_px(&mut self, scroll_offset_px: i64) {
         let line_height = self.line_height_px;
         self.locations.iter_mut().for_each(|(index, location)| {
             let base_offset = Self::bucket_base_scroll_offset(*index, line_height);

--- a/src/terminal/scroll_locations.rs
+++ b/src/terminal/scroll_locations.rs
@@ -66,7 +66,7 @@ impl ScrollLocations {
         let location = match self.locations.entry(bucket_key) {
             Entry::Occupied(occupied) => occupied.into_mut().location.clone(),
             Entry::Vacant(vacant) => {
-                let matrix_scroll_offset_px = bucket_top_px - self.scroll_offset_px as i64;
+                let matrix_scroll_offset_px = bucket_top_px - self.scroll_offset_px;
                 let matrix = scene.stage(Matrix::from_translation(
                     (0., matrix_scroll_offset_px as f64, 0.).into(),
                 ));
@@ -88,7 +88,7 @@ impl ScrollLocations {
         let line_height = self.line_height_px;
         self.locations.iter_mut().for_each(|(index, location)| {
             let base_offset = Self::bucket_base_scroll_offset(*index, line_height);
-            let new_scroll_offset = base_offset as i64 - scroll_offset_px as i64;
+            let new_scroll_offset = base_offset as i64 - scroll_offset_px;
             if new_scroll_offset != location.matrix_scroll_offset_px {
                 location.matrix_scroll_offset_px = new_scroll_offset;
                 location

--- a/src/terminal/scroll_locations.rs
+++ b/src/terminal/scroll_locations.rs
@@ -125,9 +125,9 @@ impl ScrollLocations {
     /// The bucket's base scroll offset.
     ///
     /// This added to the scroll offset in `ScrollLocation` makes up the final scroll offset.
-    fn bucket_base_scroll_offset(index: BucketKey, line_height: u32) -> u64 {
+    fn bucket_base_scroll_offset(index: BucketKey, line_height: u32) -> i64 {
         let top = Self::bucket_stable_range(index).start;
-        top as u64 * line_height as u64
+        top as i64 * line_height as i64
     }
 
     fn bucket_key(stable_index: StableRowIndex) -> BucketKey {

--- a/src/terminal/selection.rs
+++ b/src/terminal/selection.rs
@@ -7,63 +7,64 @@ use wezterm_term::StableRowIndex;
 use crate::{range_ops::RangeOps, window_geometry::CellPoint};
 
 #[derive(Debug, Default)]
-pub struct Selection {
-    state: SelectionState,
+pub enum Selection {
+    #[default]
+    Unselected,
+    Begun {
+        pos: SelectionPos,
+    },
+    Selecting(SelectionRange),
+    Selected(NormalizedSelectionRange),
 }
 
 impl Selection {
     pub fn begin(&mut self, pos: SelectionPos) {
-        self.state = SelectionState::Begun { pos }
+        *self = Self::Begun { pos }
     }
 
     pub fn can_progress(&self) -> bool {
-        matches!(
-            self.state,
-            SelectionState::Begun { .. } | SelectionState::Selecting { .. }
-        )
+        matches!(self, Self::Begun { .. } | Self::Selecting { .. })
     }
 
     pub fn progress(&mut self, ending_pos: SelectionPos) {
-        self.state = match &self.state {
-            SelectionState::Begun { pos } => {
-                SelectionState::Selecting(SelectionRange::new(*pos, ending_pos))
-            }
-            SelectionState::Selecting(SelectionRange { start, .. }) => {
-                SelectionState::Selecting(SelectionRange::new(*start, ending_pos))
+        *self = match &self {
+            Self::Begun { pos } => Self::Selecting(SelectionRange::new(*pos, ending_pos)),
+            Self::Selecting(SelectionRange { start, .. }) => {
+                Self::Selecting(SelectionRange::new(*start, ending_pos))
             }
             _ => {
                 error!(
                     "Internal error: Selection is progressing, but state is {:?}",
-                    self.state
+                    self
                 );
-                SelectionState::Unselected
+                Self::Unselected
             }
         };
     }
 
     pub fn end(&mut self) {
-        self.state = match &self.state {
-            SelectionState::Begun { .. } => SelectionState::Unselected,
-            SelectionState::Selecting(range) => SelectionState::Selected(range.normalized()),
+        *self = match &self {
+            Self::Begun { .. } => Self::Unselected,
+            Self::Selecting(range) => Self::Selected(range.normalized()),
             _ => {
                 error!(
                     "Internal error: Selection is ending, but state is {:?}",
-                    self.state
+                    self
                 );
-                SelectionState::Unselected
+                Self::Unselected
             }
         }
     }
 
     pub fn reset(&mut self) {
-        self.state = SelectionState::Unselected;
+        *self = Self::Unselected;
     }
 
     // Normalized selection range
     pub fn range(&self) -> Option<NormalizedSelectionRange> {
-        match self.state {
-            SelectionState::Selecting(range) => Some(range.normalized()),
-            SelectionState::Selected(range) => Some(range),
+        match self {
+            Self::Selecting(range) => Some(range.normalized()),
+            Self::Selected(range) => Some(*range),
             _ => None,
         }
     }
@@ -90,17 +91,6 @@ impl SelectionPos {
         assert!(self.row >= 0);
         (self.column, self.row as usize).into()
     }
-}
-
-#[derive(Debug, Default)]
-pub enum SelectionState {
-    #[default]
-    Unselected,
-    Begun {
-        pos: SelectionPos,
-    },
-    Selecting(SelectionRange),
-    Selected(NormalizedSelectionRange),
 }
 
 /// Selection range.

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -10,7 +10,6 @@ use cosmic_text::{
     Attrs, AttrsList, BufferLine, CacheKey, Family, FontSystem, LineEnding, Shaping, SubpixelBin,
     Wrap,
 };
-use log::debug;
 use rangeset::RangeSet;
 use tuple::Map;
 

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -651,13 +651,14 @@ impl TerminalView {
         terminal_geometry: &TerminalGeometry,
     ) {
         match selection {
-            Some(selection) => {
+            Some(selection_range) => {
                 // Robustness: A selection can span a lot of lines here, even the ones outside. To
                 // keep the numerical stability in the matrix, we should clip the rects to the
                 // visible range.
-                let rects_stable = Self::selection_rects(&selection, terminal_geometry.columns());
+                let rects_stable =
+                    Self::selection_rects(&selection_range, terminal_geometry.columns());
                 let cell_size = terminal_geometry.cell_size_px.map(f64::from);
-                let location_stable_index = selection.stable_rows().start;
+                let location_stable_index = selection_range.stable_rows().start;
 
                 let (location, top_px) = self
                     .locations
@@ -683,11 +684,12 @@ impl TerminalView {
                 //
                 match &mut self.selection {
                     Some(selection) => {
+                        selection.row_range = selection_range.stable_rows();
                         selection.visual.update_if_changed(visual);
                     }
                     None => {
                         self.selection = Some(SelectionVisual {
-                            row_range: selection.stable_rows(),
+                            row_range: selection_range.stable_rows(),
                             visual: scene.stage(visual),
                         })
                     }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -149,21 +149,6 @@ impl TerminalView {
         );
     }
 
-    /// The resting (finalized animation) scroll index.
-    ///
-    /// The _resting_ position is never negative.
-    fn resting_scroll_offset(&self) -> StableRowIndex {
-        // Detail: Using div_euclid here so that we can change this to support negative values.
-        self.resting_scroll_offset_px()
-            .div_euclid(self.line_height_px() as u64) as StableRowIndex
-    }
-
-    fn resting_scroll_offset_px(&self) -> u64 {
-        let resting = self.scroll_offset_px.final_value().round() as i64;
-        assert!(resting >= 0);
-        resting as u64
-    }
-
     fn animating_scroll_offset_px_snapped(&self) -> i64 {
         self.scroll_offset_px.value().round() as i64
     }

--- a/src/terminal/view.rs
+++ b/src/terminal/view.rs
@@ -62,7 +62,7 @@ pub struct TerminalView {
     /// May be negative while animating.
     scroll_offset_px: Animated<f64>,
 
-    /// The first line's stable index in  visible lines.
+    /// The first line's stable index in visible lines.
     first_line_stable_index: StableRowIndex,
 
     /// The visible lines. This contains _only_ the lines currently visible in the terminal.


### PR DESCRIPTION
This PR adds selection scrolling to the terminal. By moving the cursor / mouse above or below the view the pixel distance about how fast the view should scroll.